### PR TITLE
Add dashboard React project skeleton

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,22 @@
+# Esaltare Dashboard
+
+Ce projet React est initialement configuré pour être créé avec **Create React App**.
+
+## Installation
+
+```bash
+cd esaltare-dashboard
+npm install
+```
+
+## Démarrage du serveur de développement
+
+```bash
+npm start
+```
+
+## Construire la version de production
+
+```bash
+npm run build
+```

--- a/dashboard/esaltare-dashboard/.gitignore
+++ b/dashboard/esaltare-dashboard/.gitignore
@@ -1,0 +1,18 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/dashboard/esaltare-dashboard/package.json
+++ b/dashboard/esaltare-dashboard/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "esaltare-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "web-vitals": "^2.1.4"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/dashboard/esaltare-dashboard/public/index.html
+++ b/dashboard/esaltare-dashboard/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Esaltare Dashboard" />
+    <title>Esaltare Dashboard</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/dashboard/esaltare-dashboard/public/manifest.json
+++ b/dashboard/esaltare-dashboard/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "short_name": "dashboard",
+  "name": "Esaltare Dashboard",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#000000",
+  "background_color": "#ffffff"
+}

--- a/dashboard/esaltare-dashboard/public/robots.txt
+++ b/dashboard/esaltare-dashboard/public/robots.txt
@@ -1,0 +1,3 @@
+# https://www.robotstxt.org/robotstxt.html
+User-agent: *
+Disallow:

--- a/dashboard/esaltare-dashboard/src/App.css
+++ b/dashboard/esaltare-dashboard/src/App.css
@@ -1,0 +1,3 @@
+.App {
+  text-align: center;
+}

--- a/dashboard/esaltare-dashboard/src/App.js
+++ b/dashboard/esaltare-dashboard/src/App.js
@@ -1,0 +1,11 @@
+import './App.css';
+
+function App() {
+  return (
+    <div className="App">
+      <h1>Esaltare Dashboard</h1>
+    </div>
+  );
+}
+
+export default App;

--- a/dashboard/esaltare-dashboard/src/App.test.js
+++ b/dashboard/esaltare-dashboard/src/App.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+test('renders dashboard heading', () => {
+  render(<App />);
+  const headingElement = screen.getByText(/Esaltare Dashboard/i);
+  expect(headingElement).toBeInTheDocument();
+});

--- a/dashboard/esaltare-dashboard/src/index.css
+++ b/dashboard/esaltare-dashboard/src/index.css
@@ -1,0 +1,13 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}

--- a/dashboard/esaltare-dashboard/src/index.js
+++ b/dashboard/esaltare-dashboard/src/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import App from './App';
+import reportWebVitals from './reportWebVitals';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+
+reportWebVitals();

--- a/dashboard/esaltare-dashboard/src/reportWebVitals.js
+++ b/dashboard/esaltare-dashboard/src/reportWebVitals.js
@@ -1,0 +1,13 @@
+const reportWebVitals = onPerfEntry => {
+  if (onPerfEntry && onPerfEntry instanceof Function) {
+    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+      getCLS(onPerfEntry);
+      getFID(onPerfEntry);
+      getFCP(onPerfEntry);
+      getLCP(onPerfEntry);
+      getTTFB(onPerfEntry);
+    });
+  }
+};
+
+export default reportWebVitals;

--- a/dashboard/esaltare-dashboard/src/setupTests.js
+++ b/dashboard/esaltare-dashboard/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- scaffold dashboard React app under `dashboard/esaltare-dashboard`
- configure `start` and `build` scripts
- document installation and usage

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bb15fed00832c8a2cb35fa09ae7db