### PR TITLE
Add sales and stock charts using Chart.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "site-esaltarefood",
+  "version": "1.0.0",
+  "description": "Premier site",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "chart.js": "^4.4.0",
+    "chartjs-plugin-zoom": "^2.0.1",
+    "react": "^18.2.0",
+    "react-chartjs-2": "^5.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/src/components/SalesChart.js
+++ b/src/components/SalesChart.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+} from 'chart.js';
+import zoomPlugin from 'chartjs-plugin-zoom';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+  zoomPlugin
+);
+
+const defaultData = {
+  labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+  datasets: [
+    {
+      label: 'Ventes',
+      data: [120, 150, 170, 160, 180, 200, 220, 210, 230, 240, 250, 260],
+      backgroundColor: 'rgba(75, 192, 192, 0.5)',
+    },
+  ],
+};
+
+const options = {
+  responsive: true,
+  plugins: {
+    legend: { position: 'top' },
+    title: { display: true, text: 'Ventes mensuelles' },
+    zoom: {
+      pan: { enabled: true, mode: 'x' },
+      zoom: {
+        wheel: { enabled: true },
+        pinch: { enabled: true },
+        mode: 'x',
+      },
+    },
+  },
+  interaction: { mode: 'index', intersect: false },
+};
+
+function SalesChart({ data = defaultData }) {
+  return <Bar data={data} options={options} />;
+}
+
+export default SalesChart;

--- a/src/components/StockChart.js
+++ b/src/components/StockChart.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+} from 'chart.js';
+import zoomPlugin from 'chartjs-plugin-zoom';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+  zoomPlugin
+);
+
+const defaultData = {
+  labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+  datasets: [
+    {
+      label: 'Stock',
+      data: [100, 95, 90, 85, 80, 75, 70, 65, 60, 55, 50, 45],
+      borderColor: 'rgb(53, 162, 235)',
+      backgroundColor: 'rgba(53, 162, 235, 0.5)',
+    },
+  ],
+};
+
+const options = {
+  responsive: true,
+  plugins: {
+    legend: { position: 'top' },
+    title: { display: true, text: 'Niveaux de stock' },
+    zoom: {
+      pan: { enabled: true, mode: 'x' },
+      zoom: {
+        wheel: { enabled: true },
+        pinch: { enabled: true },
+        mode: 'x',
+      },
+    },
+  },
+  interaction: { mode: 'nearest', intersect: false },
+};
+
+function StockChart({ data = defaultData }) {
+  return <Line data={data} options={options} />;
+}
+
+export default StockChart;


### PR DESCRIPTION
## Summary
- add package setup with Chart.js, React, and chartjs-plugin-zoom dependencies
- create SalesChart and StockChart React components with zoom and hover interactivity

## Testing
- `npm test`
- `npm install react react-dom chart.js react-chartjs-2 chartjs-plugin-zoom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_689bb1ad688c832c853f12910257bb56