### PR TITLE
feat: add API client and chart data fetching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "site-esaltarefood",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "axios": "^1.6.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "scripts": {
+    "test": "echo 'No tests specified' && exit 0"
+  }
+}

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+const client = axios.create({
+  baseURL: process.env.REACT_APP_API_URL || 'http://localhost:3000/api',
+  timeout: 10000,
+});
+
+export const getSalesData = async () => {
+  const response = await client.get('/sales');
+  return response.data;
+};
+
+export const getStockData = async () => {
+  const response = await client.get('/stock');
+  return response.data;
+};
+
+export default client;

--- a/src/components/SalesChart.js
+++ b/src/components/SalesChart.js
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import { getSalesData } from '../api/client';
+
+const SalesChart = () => {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    let mounted = true;
+    getSalesData()
+      .then((res) => {
+        if (mounted) setData(res);
+      })
+      .catch(console.error);
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (!data) {
+    return <div>Loading sales data...</div>;
+  }
+
+  return (
+    <div>
+      <h2>Sales Chart</h2>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+};
+
+export default SalesChart;

--- a/src/components/StockChart.js
+++ b/src/components/StockChart.js
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import { getStockData } from '../api/client';
+
+const StockChart = () => {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    let mounted = true;
+    getStockData()
+      .then((res) => {
+        if (mounted) setData(res);
+      })
+      .catch(console.error);
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (!data) {
+    return <div>Loading stock data...</div>;
+  }
+
+  return (
+    <div>
+      <h2>Stock Chart</h2>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+};
+
+export default StockChart;


### PR DESCRIPTION
## Summary
- configure Axios client for API calls
- add sales and stock data fetch helpers
- load sales and stock data in chart components using React hooks

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689bb1ae0844832c887270dd19f0399a