### PR TITLE
docs: add deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # site-esaltarefood
-Premier site 
+
+Premier site
+
+## Production
+La version de production est disponible à l'adresse suivante :
+https://example.netlify.app/
+
+## Déploiement
+1. Installer les dépendances : `npm install`
+2. Construire le site : `npm run build`
+3. Déployer sur Netlify :
+   - Connecter le dépôt à Netlify
+   - Définir la commande de build à `npm run build`
+   - Définir le répertoire de publication à `build`

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "build"


### PR DESCRIPTION
## Summary
- document production URL and deployment steps
- add Netlify configuration file

## Testing
- `npm run build` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689bb1b04de8832c8fe5272ed3b878d4