### PR TITLE
test: add initial dashboard tests

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,11 @@
+# Dashboard
+
+## Tests
+
+Après avoir installé les dépendances (`npm install`), exécutez :
+
+```bash
+npm test
+```
+
+Cela lance Jest avec React Testing Library.

--- a/dashboard/babel.config.js
+++ b/dashboard/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    ['@babel/preset-react', {runtime: 'automatic'}]
+  ]
+};

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "dashboard",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.16.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.22.20",
+    "@babel/preset-env": "^7.22.20",
+    "@babel/preset-react": "^7.18.6",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^14.0.0",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0"
+  }
+}

--- a/dashboard/src/App.js
+++ b/dashboard/src/App.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import SalesChart from './components/SalesChart';
+import Stocks from './components/Stocks';
+import Clients from './components/Clients';
+
+const App = () => (
+  <Routes>
+    <Route path="/ventes" element={<SalesChart />} />
+    <Route path="/stocks" element={<Stocks />} />
+    <Route path="/clients" element={<Clients />} />
+  </Routes>
+);
+
+export default App;

--- a/dashboard/src/__tests__/App.test.js
+++ b/dashboard/src/__tests__/App.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import App from '../App';
+
+test('navigates to /ventes', () => {
+  render(
+    <MemoryRouter initialEntries={['/ventes']}>
+      <App />
+    </MemoryRouter>
+  );
+  expect(screen.getByText(/Sales Chart/i)).toBeInTheDocument();
+});
+
+test('navigates to /stocks', () => {
+  render(
+    <MemoryRouter initialEntries={['/stocks']}>
+      <App />
+    </MemoryRouter>
+  );
+  expect(screen.getByText(/Stocks Page/i)).toBeInTheDocument();
+});
+
+test('navigates to /clients', () => {
+  render(
+    <MemoryRouter initialEntries={['/clients']}>
+      <App />
+    </MemoryRouter>
+  );
+  expect(screen.getByText(/Clients Page/i)).toBeInTheDocument();
+});

--- a/dashboard/src/components/Clients.js
+++ b/dashboard/src/components/Clients.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Clients = () => <div>Clients Page</div>;
+
+export default Clients;

--- a/dashboard/src/components/SalesChart.js
+++ b/dashboard/src/components/SalesChart.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const SalesChart = () => {
+  return <div>Sales Chart</div>;
+};
+
+export default SalesChart;

--- a/dashboard/src/components/Stocks.js
+++ b/dashboard/src/components/Stocks.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Stocks = () => <div>Stocks Page</div>;
+
+export default Stocks;

--- a/dashboard/src/components/__tests__/SalesChart.test.js
+++ b/dashboard/src/components/__tests__/SalesChart.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SalesChart from '../SalesChart';
+
+test('renders SalesChart component', () => {
+  render(<SalesChart />);
+  expect(screen.getByText(/Sales Chart/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- set up dashboard module with Jest and React Testing Library configuration
- add SalesChart component and unit test
- add App routing tests for ventes, stocks and clients
- document test usage in dashboard README

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bb419eac0832c853d5259adb1935e