### PR TITLE
Set up GitHub Actions build and deploy pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm test
+      - name: Build
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # site-esaltarefood
-Premier site 
+
+Premier site.
+
+## Déploiement
+
+Le dépôt est configuré avec GitHub Actions pour exécuter automatiquement les tests (`npm test`) puis la construction (`npm run build`) à chaque push sur la branche principale. Le contenu généré dans le dossier `dist/` est ensuite déployé sur GitHub Pages.
+
+Aucun action manuelle n'est nécessaire : poussez simplement vos modifications pour lancer le processus de déploiement.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run npm test & build and deploy to GitHub Pages
- document automated deployment steps in README

## Testing
- `npm test` (fails: no package.json)
- `npm run build` (fails: no package.json)


------
https://chatgpt.com/codex/tasks/task_b_689bb4216230832c96830d712796f571