### PR TITLE
feat: add express api server

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "api",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "dotenv": "^16.0.3"
+  }
+}

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -1,0 +1,13 @@
+require('dotenv').config();
+const express = require('express');
+
+const app = express();
+
+app.get('/', (req, res) => {
+  res.send('Hello World');
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- initialize API folder with package.json
- add basic Express server using dotenv

## Testing
- `npm install express dotenv` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_689bb6cca434832c88ae013b9d8e4543