### PR TITLE
Add MongoDB configuration and core models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "site-esaltarefood",
+  "version": "1.0.0",
+  "description": "Premier site",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No test specified\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "mongoose": "^8.0.0"
+  }
+}

--- a/src/config/db.js
+++ b/src/config/db.js
@@ -1,0 +1,22 @@
+const mongoose = require('mongoose');
+
+/**
+ * Establish a connection to the MongoDB database.
+ * Uses the `MONGODB_URI` environment variable or defaults to a local database.
+ */
+async function connectDB() {
+  const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/esaltarefood';
+  try {
+    const conn = await mongoose.connect(uri, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+    console.log(`MongoDB Connected: ${conn.connection.host}`);
+    return conn;
+  } catch (err) {
+    console.error('MongoDB connection error:', err.message);
+    process.exit(1);
+  }
+}
+
+module.exports = connectDB;

--- a/src/models/Client.js
+++ b/src/models/Client.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const ClientSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    email: { type: String, required: true, unique: true },
+    phone: { type: String },
+    address: { type: String },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Client', ClientSchema);

--- a/src/models/Sale.js
+++ b/src/models/Sale.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+
+const SaleSchema = new mongoose.Schema(
+  {
+    client: { type: mongoose.Schema.Types.ObjectId, ref: 'Client', required: true },
+    items: [
+      {
+        product: { type: String, required: true },
+        quantity: { type: Number, required: true },
+        price: { type: Number, required: true },
+      },
+    ],
+    total: { type: Number, required: true },
+    date: { type: Date, default: Date.now },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Sale', SaleSchema);

--- a/src/models/Stock.js
+++ b/src/models/Stock.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const StockSchema = new mongoose.Schema(
+  {
+    product: { type: String, required: true },
+    quantity: { type: Number, default: 0 },
+    updatedAt: { type: Date, default: Date.now },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Stock', StockSchema);


### PR DESCRIPTION
## Summary
- configure MongoDB connection with mongoose
- define Sale, Stock, and Client Mongoose models
- set up package.json with mongoose dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689bb6cdec28832c83ee9090954b2daa