### PR TITLE
Add Express API routers for sales, stocks, and clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "site-esaltarefood",
+  "version": "1.0.0",
+  "description": "Premier site",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const app = express();
+
+app.use(express.json());
+
+const salesRouter = require('./src/routes/sales');
+const stocksRouter = require('./src/routes/stocks');
+const clientsRouter = require('./src/routes/clients');
+
+app.use('/api/sales', salesRouter);
+app.use('/api/stocks', stocksRouter);
+app.use('/api/clients', clientsRouter);
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/src/routes/clients.js
+++ b/src/routes/clients.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  res.json({ message: 'GET clients' });
+});
+
+router.post('/', (req, res) => {
+  res.json({ message: 'POST clients' });
+});
+
+router.put('/:id', (req, res) => {
+  res.json({ message: `PUT clients ${req.params.id}` });
+});
+
+router.delete('/:id', (req, res) => {
+  res.json({ message: `DELETE clients ${req.params.id}` });
+});
+
+module.exports = router;

--- a/src/routes/sales.js
+++ b/src/routes/sales.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  res.json({ message: 'GET sales' });
+});
+
+router.post('/', (req, res) => {
+  res.json({ message: 'POST sales' });
+});
+
+router.put('/:id', (req, res) => {
+  res.json({ message: `PUT sales ${req.params.id}` });
+});
+
+router.delete('/:id', (req, res) => {
+  res.json({ message: `DELETE sales ${req.params.id}` });
+});
+
+module.exports = router;

--- a/src/routes/stocks.js
+++ b/src/routes/stocks.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  res.json({ message: 'GET stocks' });
+});
+
+router.post('/', (req, res) => {
+  res.json({ message: 'POST stocks' });
+});
+
+router.put('/:id', (req, res) => {
+  res.json({ message: `PUT stocks ${req.params.id}` });
+});
+
+router.delete('/:id', (req, res) => {
+  res.json({ message: `DELETE stocks ${req.params.id}` });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- set up Express server wiring sales, stocks, and clients routers under `/api`
- add sales, stocks, and clients routers with GET/POST/PUT/DELETE handlers

## Testing
- `npm test` (fails: Error: no test specified)
- `node server.js` (fails: Cannot find module 'express')

------
https://chatgpt.com/codex/tasks/task_b_689bb6cf03fc832c85f7b9d2782950f5