### PR TITLE
Add JWT auth route and middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "site-esaltarefood",
+  "version": "1.0.0",
+  "description": "Premier site",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "bcrypt": "^5.1.1",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const authRoutes = require('./routes/auth');
+const auth = require('./middleware/auth');
+
+const app = express();
+app.use(express.json());
+
+app.use('/auth', authRoutes);
+
+// Exemple de route protégée
+app.get('/protected', auth, (req, res) => {
+  res.json({ message: 'Accès autorisé', user: req.user });
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Serveur démarré sur le port ${port}`);
+});

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,0 +1,17 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = (req, res, next) => {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader) {
+    return res.status(401).json({ error: 'Token requis' });
+  }
+
+  const token = authHeader.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secretkey');
+    req.user = decoded;
+    next();
+  } catch (err) {
+    res.status(401).json({ error: 'Token invalide' });
+  }
+};

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+
+const router = express.Router();
+
+// Utilisateur fictif pour l'exemple
+const users = [
+  {
+    id: 1,
+    username: 'admin',
+    // Hash d'un mot de passe "password"
+    passwordHash: bcrypt.hashSync('password', 10)
+  }
+];
+
+router.post('/login', async (req, res) => {
+  const { username, password } = req.body;
+  const user = users.find(u => u.username === username);
+  if (!user) {
+    return res.status(401).json({ error: 'Identifiants invalides' });
+  }
+
+  try {
+    const match = await bcrypt.compare(password, user.passwordHash);
+    if (!match) {
+      return res.status(401).json({ error: 'Identifiants invalides' });
+    }
+
+    const token = jwt.sign(
+      { id: user.id, username: user.username },
+      process.env.JWT_SECRET || 'secretkey',
+      { expiresIn: '1h' }
+    );
+
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add JSON Web Token login endpoint with bcrypt password check
- secure other endpoints via auth middleware
- configure Node project with dependencies

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_689bb6cf0d84832c9dbb8dbb7138c18a