### PR TITLE
feat: add global error handler with validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "site-esaltarefood",
+  "version": "1.0.0",
+  "description": "Premier site",
+  "main": "src/app.js",
+  "scripts": {
+    "test": "echo \"No tests\"",
+    "start": "node src/app.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "express-validator": "^6.14.3"
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const { body, validationResult } = require('express-validator');
+const errorHandler = require('./middleware/errorHandler');
+
+const app = express();
+app.use(express.json());
+
+app.post('/users',
+  body('email').isEmail().withMessage('Valid email is required'),
+  body('password').isLength({ min: 6 }).withMessage('Password must be at least 6 characters long'),
+  (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array().map(e => e.msg) });
+    }
+    res.json({ message: 'User created' });
+  }
+);
+
+app.get('/error', (req, res, next) => {
+  next(new Error('Something went wrong'));
+});
+
+app.use(errorHandler);
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+
+module.exports = app;

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,0 +1,8 @@
+function errorHandler(err, req, res, next) {
+  console.error(err);
+  const status = err.status || 500;
+  const message = err.message || 'Internal Server Error';
+  res.status(status).json({ message });
+}
+
+module.exports = errorHandler;


### PR DESCRIPTION
## Summary
- add global error handler middleware
- validate route inputs with express-validator
- set up basic express app and npm scripts

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `npm test`
- `node src/app.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_689bb6cf65a0832c9849e89ee0fe4313