### PR TITLE
Add Jest and Supertest route tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # site-esaltarefood
-Premier site 
+
+Premier site
+
+## Tests
+
+Ce projet utilise Jest et Supertest pour vérifier les routes HTTP.
+Après avoir installé les dépendances avec `npm install`,
+lancez la suite de tests avec :
+
+```
+npm test
+```

--- a/app.js
+++ b/app.js
@@ -1,0 +1,16 @@
+const http = require('http');
+
+const app = http.createServer((req, res) => {
+  if (req.url === '/sales' && req.method === 'GET') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ message: 'Sales route' }));
+  } else if (req.url === '/stocks' && req.method === 'GET') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ message: 'Stocks route' }));
+  } else {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not Found' }));
+  }
+});
+
+module.exports = app;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "site-esaltarefood",
+  "version": "1.0.0",
+  "description": "Premier site",
+  "main": "app.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
+  }
+}

--- a/tests/sales.test.js
+++ b/tests/sales.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../app');
+
+describe('GET /sales', () => {
+  it('returns sales route', async () => {
+    const res = await request(app).get('/sales');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ message: 'Sales route' });
+  });
+});

--- a/tests/stocks.test.js
+++ b/tests/stocks.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../app');
+
+describe('GET /stocks', () => {
+  it('returns stocks route', async () => {
+    const res = await request(app).get('/stocks');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ message: 'Stocks route' });
+  });
+});


### PR DESCRIPTION
## Summary
- add minimal HTTP server exposing `/sales` and `/stocks` routes
- configure Jest + Supertest with tests for each route
- document `npm test` usage

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bb6d0a510832c872c4a310ec915b0