### PR TITLE
Add express API with Swagger docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+api/node_modules/

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,22 @@
+# API Esaltare Food
+
+Cette API est construite avec [Express](https://expressjs.com/) et fournit une documentation interactive via Swagger.
+
+## Installation
+
+```bash
+cd api
+npm install
+npm start
+```
+
+Le serveur est disponible par défaut sur `http://localhost:3000`.
+
+## Routes
+
+- `GET /` – message de bienvenue.
+- `GET /api-docs` – documentation interactive Swagger.
+
+## Développement
+
+Les dépendances Swagger peuvent être retirées si la documentation interactive n'est pas nécessaire.

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const swaggerJsdoc = require('swagger-jsdoc');
+const swaggerUi = require('swagger-ui-express');
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+const swaggerOptions = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'Esaltare Food API',
+      version: '1.0.0',
+    },
+  },
+  apis: ['./index.js'],
+};
+
+const swaggerSpec = swaggerJsdoc(swaggerOptions);
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+
+/**
+ * @swagger
+ * /:
+ *   get:
+ *     summary: Affiche un message de bienvenue
+ *     responses:
+ *       200:
+ *         description: Message de bienvenue
+ */
+app.get('/', (req, res) => {
+  res.json({ message: "Bienvenue sur l'API Esaltare Food" });
+});
+
+app.listen(port, () => {
+  console.log(`Serveur lancé sur http://localhost:${port}`);
+});

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "esaltarefood-api",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "swagger-ui-express": "^4.6.3",
+    "swagger-jsdoc": "^6.2.8"
+  }
+}


### PR DESCRIPTION
## Summary
- create Express API with Swagger documentation
- document installation and routes in `api/README.md`

## Testing
- `npm install` (fails: 403 Forbidden - express)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689bb6d21730832cbf9409f3baaf2ab3